### PR TITLE
override verify_found_host method to provide proper return value

### DIFF
--- a/app/controllers/concerns/foreman_ipxe/unattended_controller_extensions.rb
+++ b/app/controllers/concerns/foreman_ipxe/unattended_controller_extensions.rb
@@ -53,6 +53,12 @@ module ForemanIpxe
 
         super
       end
+
+      def verify_found_host
+        return false if host_not_found?(@host) || host_os_is_missing?(@host) || host_os_family_is_missing?(@host)
+        logger.debug "Found #{@host}"
+        true
+      end
     end
 
     included do


### PR DESCRIPTION
I found a small issue while testing this as `verify_found_host` does not return a proper return value. This PR contains the fix.

@ananace: If you could release a new patch version with this, that'd be lovely.